### PR TITLE
Fix compilation for ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Requirements
 
 Running this controller requires:
 - [Ceres library](https://github.com/ceres-solver/ceres-solver)
+  Note: On ubuntu 16.04 you need [ceres 1.14](https://github.com/ceres-solver/ceres-solver/tree/1.14.x)
 - [mc_rtc](https://github.com/jrl-umi3218/mc_rtc)
 - `C++14`
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,13 @@ set(controller_HDR
 
 add_library(${PROJECT_NAME} SHARED ${controller_SRC} ${controller_HDR})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DForceSensorCalibration_EXPORTS")
-target_link_libraries(${PROJECT_NAME} PUBLIC mc_rtc::mc_control_fsm ${CERES_LIBRARIES})
-target_include_directories(${PROJECT_NAME} PUBLIC ${CERES_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PUBLIC mc_rtc::mc_control_fsm)
+if(TARGET Ceres::ceres)
+  target_link_libraries(${PROJECT_NAME} PUBLIC Ceres::ceres)
+else()
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${CERES_LIBRARIES})
+  target_include_directories(${PROJECT_NAME} PUBLIC ${CERES_INCLUDE_DIRS})
+endif()
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION "${MC_RTC_LIBDIR}"
   LIBRARY DESTINATION "${MC_RTC_LIBDIR}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,8 @@ set(controller_HDR
 
 add_library(${PROJECT_NAME} SHARED ${controller_SRC} ${controller_HDR})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DForceSensorCalibration_EXPORTS")
-target_link_libraries(${PROJECT_NAME} PUBLIC mc_rtc::mc_control_fsm Ceres::ceres)
+target_link_libraries(${PROJECT_NAME} PUBLIC mc_rtc::mc_control_fsm ${CERES_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${CERES_INCLUDE_DIRS})
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION "${MC_RTC_LIBDIR}"
   LIBRARY DESTINATION "${MC_RTC_LIBDIR}"


### PR DESCRIPTION
Latest ceres requires Eigen 3.3, which is different version from the apt-installed Eigen in Ubuntu16.04. On ubuntu 16.04 we can use ceres-solver 1.14, but it only exports old cmake targets, so we need to adapt the cmake.
