### PR TITLE
Lower calibration thread priority

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,15 +18,13 @@ on:
 
 jobs:
   clang-format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Install clang-format-6.0
+    - name: Install clang-format-10
       run: |
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get -qq update
-        sudo apt-get -qq remove clang-6.0 libclang1-6.0 libclang-common-6.0-dev libllvm6.0
-        sudo apt-get -qq install clang-format-6.0 clang-format
+        sudo apt-get -qq install clang-format-10
     - name: Run clang-format-check
       run: |
         ./.clang-format-check.sh

--- a/src/states/CalibrationMotion.cpp
+++ b/src/states/CalibrationMotion.cpp
@@ -65,13 +65,15 @@ void CalibrationMotion::start(mc_control::fsm::Controller & ctl)
         });
   }
 
-  ctl.gui()->addElement(
-      {}, mc_rtc::gui::NumberSlider("Progress", [this]() { return dt_; }, [](double) {}, 0, duration_),
-      mc_rtc::gui::Button("Stop Motion", [this]() {
-        mc_rtc::log::warning("[{}] Motion was interrupted before it's planned duration ({:.2f}/{:.2f}s)", name(), dt_,
-                             duration_);
-        interrupted_ = true;
-      }));
+  ctl.gui()->addElement({},
+                        mc_rtc::gui::NumberSlider(
+                            "Progress", [this]() { return dt_; }, [](double) {}, 0, duration_),
+                        mc_rtc::gui::Button("Stop Motion", [this]() {
+                          mc_rtc::log::warning(
+                              "[{}] Motion was interrupted before it's planned duration ({:.2f}/{:.2f}s)", name(), dt_,
+                              duration_);
+                          interrupted_ = true;
+                        }));
 }
 
 bool CalibrationMotion::run(mc_control::fsm::Controller & ctl_)

--- a/src/states/CheckResults.cpp
+++ b/src/states/CheckResults.cpp
@@ -48,18 +48,21 @@ void CheckResults::start(mc_control::fsm::Controller & ctl)
 
     ctl.gui()->addPlot(
         sensorN, plot::X({"t", {t_ + 0, t_ + duration}}, [this]() { return t_; }),
-        plot::Y("Wrenches calibrated (x)",
-                [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().x(); }, Color::Red,
-                Style::Solid),
-        plot::Y("Wrenches calibrated (y)",
-                [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().y(); }, Color::Green,
-                Style::Solid),
-        plot::Y("Wrenches calibrated (y)",
-                [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().z(); }, Color::Blue,
-                Style::Solid),
-        plot::Y("Wrenches raw(x)", [&sensor]() { return sensor.wrench().force().x(); }, Color::Red, Style::Dashed),
-        plot::Y("Wrenches raw(y)", [&sensor]() { return sensor.wrench().force().y(); }, Color::Green, Style::Dashed),
-        plot::Y("Wrenches raw(z)", [&sensor]() { return sensor.wrench().force().z(); }, Color::Blue, Style::Dashed));
+        plot::Y(
+            "Wrenches calibrated (x)", [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().x(); },
+            Color::Red, Style::Solid),
+        plot::Y(
+            "Wrenches calibrated (y)", [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().y(); },
+            Color::Green, Style::Solid),
+        plot::Y(
+            "Wrenches calibrated (y)", [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().z(); },
+            Color::Blue, Style::Solid),
+        plot::Y(
+            "Wrenches raw(x)", [&sensor]() { return sensor.wrench().force().x(); }, Color::Red, Style::Dashed),
+        plot::Y(
+            "Wrenches raw(y)", [&sensor]() { return sensor.wrench().force().y(); }, Color::Green, Style::Dashed),
+        plot::Y(
+            "Wrenches raw(z)", [&sensor]() { return sensor.wrench().force().z(); }, Color::Blue, Style::Dashed));
   }
 
   ctl.gui()->addElement(

--- a/src/states/RunCalibrationScript.cpp
+++ b/src/states/RunCalibrationScript.cpp
@@ -73,15 +73,20 @@ void RunCalibrationScript::start(mc_control::fsm::Controller & ctl_)
     }
     completed_ = true;
   });
+#ifndef WIN32
   // Lower thread priority so that it has a lesser priority than the real time
   // thread
   auto th_handle = th_.native_handle();
   int policy = 0;
   sched_param param{};
   pthread_getschedparam(th_handle, &policy, &param);
-  mc_rtc::log::info("[{}] Calibration thread priority: {}", name(), param.sched_priority);
   param.sched_priority = 80;
-  pthread_setschedparam(th_handle, SCHED_RR, &param);
+  if(pthread_setschedparam(th_handle, SCHED_RR, &param) != 0)
+  {
+    mc_rtc::log::warning("[{}] Failed to lower calibration thread priority. If you are running on a real-time system, "
+                         "this might cause latency to the real-time loop.");
+  }
+#endif
 }
 
 bool RunCalibrationScript::run(mc_control::fsm::Controller &)

--- a/src/states/RunCalibrationScript.cpp
+++ b/src/states/RunCalibrationScript.cpp
@@ -73,6 +73,15 @@ void RunCalibrationScript::start(mc_control::fsm::Controller & ctl_)
     }
     completed_ = true;
   });
+  // Lower thread priority so that it has a lesser priority than the real time
+  // thread
+  auto th_handle = th_.native_handle();
+  int policy = 0;
+  sched_param param{};
+  pthread_getschedparam(th_handle, &policy, &param);
+  mc_rtc::log::info("[{}] Calibration thread priority: {}", name(), param.sched_priority);
+  param.sched_priority = 80;
+  pthread_setschedparam(th_handle, SCHED_RR, &param);
 }
 
 bool RunCalibrationScript::run(mc_control::fsm::Controller &)

--- a/src/states/ShowForces.cpp
+++ b/src/states/ShowForces.cpp
@@ -17,9 +17,12 @@ void ShowForces::addWrenchPlot(const std::string & name,
                                const mc_rbdyn::ForceSensor & fs)
 {
   gui.addPlot(name, plot::X("t", [this]() { return t_; }),
-              plot::Y(name + " (x)", [&fs]() { return fs.wrench().force().x(); }, Color::Red, Style::Dashed),
-              plot::Y(name + " (y)", [&fs]() { return fs.wrench().force().y(); }, Color::Green, Style::Dashed),
-              plot::Y(name + " (z)", [&fs]() { return fs.wrench().force().z(); }, Color::Blue, Style::Dashed));
+              plot::Y(
+                  name + " (x)", [&fs]() { return fs.wrench().force().x(); }, Color::Red, Style::Dashed),
+              plot::Y(
+                  name + " (y)", [&fs]() { return fs.wrench().force().y(); }, Color::Green, Style::Dashed),
+              plot::Y(
+                  name + " (z)", [&fs]() { return fs.wrench().force().z(); }, Color::Blue, Style::Dashed));
   plots_.push_back(name);
 }
 
@@ -29,12 +32,15 @@ void ShowForces::addWrenchWithoutGravityPlot(const std::string & name,
                                              const mc_rbdyn::ForceSensor & fs)
 {
   gui.addPlot(name, plot::X("t", [this]() { return t_; }),
-              plot::Y(name + " (x)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().x(); }, Color::Red,
-                      Style::Dashed),
-              plot::Y(name + " (y)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().y(); },
-                      Color::Green, Style::Dashed),
-              plot::Y(name + " (z)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().z(); },
-                      Color::Blue, Style::Dashed));
+              plot::Y(
+                  name + " (x)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().x(); }, Color::Red,
+                  Style::Dashed),
+              plot::Y(
+                  name + " (y)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().y(); }, Color::Green,
+                  Style::Dashed),
+              plot::Y(
+                  name + " (z)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().z(); }, Color::Blue,
+                  Style::Dashed));
   plots_.push_back(name);
 }
 
@@ -45,12 +51,15 @@ void ShowForces::addWrenchWithoutGravityPlot(const std::string & name,
                                              const mc_rbdyn::ForceSensor & fs)
 {
   gui.addPlot(name, plot::X("t", [this]() { return t_; }),
-              plot::Y(name + " (x)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().x(); },
-                      Color::Red, Style::Dashed),
-              plot::Y(name + " (y)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().y(); },
-                      Color::Green, Style::Dashed),
-              plot::Y(name + " (z)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().z(); },
-                      Color::Blue, Style::Dashed));
+              plot::Y(
+                  name + " (x)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().x(); },
+                  Color::Red, Style::Dashed),
+              plot::Y(
+                  name + " (y)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().y(); },
+                  Color::Green, Style::Dashed),
+              plot::Y(
+                  name + " (z)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().z(); },
+                  Color::Blue, Style::Dashed));
   plots_.push_back(name);
 }
 
@@ -59,8 +68,9 @@ void ShowForces::addWrenchVector(const std::string & name,
                                  const mc_rbdyn::Robot & robot,
                                  const mc_rbdyn::ForceSensor & fs)
 {
-  gui.addElement(category_, Force(name, forceConfig_, [&fs]() { return fs.wrench(); },
-                                  [&fs, &robot]() { return fs.X_0_f(robot); }));
+  gui.addElement(category_,
+                 Force(
+                     name, forceConfig_, [&fs]() { return fs.wrench(); }, [&fs, &robot]() { return fs.X_0_f(robot); }));
 }
 
 void ShowForces::addWrenchWithoutGravityVector(const std::string & name,
@@ -68,8 +78,9 @@ void ShowForces::addWrenchWithoutGravityVector(const std::string & name,
                                                const mc_rbdyn::Robot & robot,
                                                const mc_rbdyn::ForceSensor & fs)
 {
-  gui.addElement(category_, Force(name, forceConfig_, [&fs, &robot]() { return fs.wrenchWithoutGravity(robot); },
-                                  [&fs, &robot]() { return fs.X_0_f(robot); }));
+  gui.addElement(category_, Force(
+                                name, forceConfig_, [&fs, &robot]() { return fs.wrenchWithoutGravity(robot); },
+                                [&fs, &robot]() { return fs.X_0_f(robot); }));
 }
 
 void ShowForces::addWrenchWithoutGravityVector(const std::string & name,
@@ -78,8 +89,9 @@ void ShowForces::addWrenchWithoutGravityVector(const std::string & name,
                                                const mc_rbdyn::Robot & robot,
                                                const mc_rbdyn::ForceSensor & fs)
 {
-  gui.addElement(category_, Force(name, forceConfig_, [&fs, &robot, surface]() { return robot.surfaceWrench(surface); },
-                                  [&fs, &robot, surface]() { return robot.surfacePose(surface); }));
+  gui.addElement(category_, Force(
+                                name, forceConfig_, [&fs, &robot, surface]() { return robot.surfaceWrench(surface); },
+                                [&fs, &robot, surface]() { return robot.surfacePose(surface); }));
 }
 
 void ShowForces::start(mc_control::fsm::Controller & ctl)
@@ -143,12 +155,12 @@ void ShowForces::start(mc_control::fsm::Controller & ctl)
     if(surfaces.size())
     {
       surfaces_[name] = surfaces.front();
-      ctl.gui()->addElement(fsCategory,
-                            mc_rtc::gui::ComboInput("Surface", surfaces, [this, name]() { return surfaces_[name]; },
-                                                    [this, name](const std::string & surface) {
-                                                      mc_rtc::log::info("[ShowForces] Surface {} selected", surface);
-                                                      surfaces_[name] = surface;
-                                                    }));
+      ctl.gui()->addElement(fsCategory, mc_rtc::gui::ComboInput(
+                                            "Surface", surfaces, [this, name]() { return surfaces_[name]; },
+                                            [this, name](const std::string & surface) {
+                                              mc_rtc::log::info("[ShowForces] Surface {} selected", surface);
+                                              surfaces_[name] = surface;
+                                            }));
       // mc  _rtc::gui::FormDataComboInput{"R0 surface", false, {"surfaces", "$R0"}},
 
       ctl.gui()->addElement(fsCategory, ElementsStacking::Horizontal,


### PR DESCRIPTION
The calibration thread inherits the real-time thread's priority. As this is a computationally intensive thread, this causes the controller to freeze while the calibration is being computed, which can take several seconds (or more if it does not converge).

This PR reduces the thread priority to avoid such issues.
This was tested on `hrp2012c`, I will merge when pipeline succeeds.