### PR TITLE
Draft: Improve/fix computation of initial guess

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,15 +18,13 @@ on:
 
 jobs:
   clang-format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Install clang-format-6.0
+    - name: Install clang-format-10
       run: |
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get -qq update
-        sudo apt-get -qq remove clang-6.0 libclang1-6.0 libclang-common-6.0-dev libllvm6.0
-        sudo apt-get -qq install clang-format-6.0 clang-format
+        sudo apt-get -qq install clang-format-10
     - name: Run clang-format-check
       run: |
         ./.clang-format-check.sh

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ To add your own robot, you should add an additional section with the same name a
 
 - `ObserverPipelines`: a state observation pipeline see [here](https://jrl-umi3218.github.io/mc_rtc/json.html#Observers/ObserverPipelines) for supported options. The calibration method requires the orientation of force sensors w.r.t gravity to be known. For floating base robots this means that you need to know at least the orientation of the floating base w.r.t gravity (roll/pitch), and the joint position in order to compute the sensor frame orientation from kinematics.
 - `forceSensors`: Vector of force sensor names to calibrate
+- `initialGuess`: [optional] Map of force sensor names to initial calibration parameters
+  ```yaml
+  initialGuess:
+    LeftHandForceSensor:
+      com: [0, 0, -0.1]
+      mass: 0.3
+      rpy: [0,0,0]
+      offset: [0,0,0,0,0,0]
+    RightHandForceSensor:
+      ...
+  ```
+  If no initial guess are provided, one will be automatically computed from the robot model. This assumes that the children links of the link to which the force sensor is attached contain the correct mass and inertia.
 - `maxPressureThreshold`: Prevent calibration motion if any of the force sensors measures more than this threhold (norm of force).
 - `initial_posture`: Initial robot posture from which the calibration motion starts.
   ```yaml

--- a/src/calibrate.h
+++ b/src/calibrate.h
@@ -1,17 +1,82 @@
+#pragma once
 #include <mc_rbdyn/Robot.h>
+#include <ostream>
 
 #include "Measurement.h"
 
+struct InitialGuess
+{
+  double mass = 0;
+  std::array<double, 3> rpy = {0};
+  std::array<double, 3> com = {0};
+  std::array<double, 6> offset = {0};
+};
+
+inline std::ostream & operator<<(std::ostream & os, const InitialGuess & r)
+{
+  // clang-format off
+  return os << fmt::format(
+R"(mass        : {}
+rpy         : {}, {}, {}
+com         : {}, {}, {}
+force offset: {}, {}, {}, {}, {}, {})",
+      r.mass,
+      r.rpy[0], r.rpy[1], r.rpy[2],
+      r.com[0], r.com[1], r.com[2],
+      r.offset[0], r.offset[1], r.offset[2], r.offset[3], r.offset[4], r.offset[5]);
+  // clang-format on
+}
+
+namespace mc_rtc
+{
+template<>
+struct ConfigurationLoader<InitialGuess>
+{
+  static InitialGuess load(const mc_rtc::Configuration & config)
+  {
+    InitialGuess r;
+    config("mass", r.mass);
+    config("com", r.com);
+    config("rpy", r.rpy);
+    config("offset", r.offset);
+    return r;
+  }
+
+  static mc_rtc::Configuration save(const InitialGuess & r)
+  {
+    mc_rtc::Configuration c;
+    c.add("mass", r.mass);
+    c.add("com", r.com);
+    c.add("rpy", r.rpy);
+    c.add("offset", r.offset);
+    return c;
+  }
+};
+} // namespace mc_rtc
+
 struct CalibrationResult
 {
+  CalibrationResult(const InitialGuess & guess)
+  {
+    mass = guess.mass;
+    rpy = guess.rpy;
+    com = guess.com;
+    offset = guess.offset;
+  }
+
   bool success = false;
   double mass = 0;
-  double rpy[3] = {0};
-  double com[3] = {0};
-  double offset[6] = {0};
+  std::array<double, 3> rpy = {0};
+  std::array<double, 3> com = {0};
+  std::array<double, 6> offset = {0};
 };
+
+InitialGuess computeInitialGuessFromModel(const mc_rbdyn::Robot & robot,
+                                          const std::string & sensor,
+                                          bool verbose = false);
 
 CalibrationResult calibrate(const mc_rbdyn::Robot & robot,
                             const std::string & sensor,
                             const Measurements & measurements,
+                            const InitialGuess & initialGuess,
                             bool verbose = false);

--- a/src/states/CalibrationMotion.cpp
+++ b/src/states/CalibrationMotion.cpp
@@ -65,13 +65,15 @@ void CalibrationMotion::start(mc_control::fsm::Controller & ctl)
         });
   }
 
-  ctl.gui()->addElement(
-      {}, mc_rtc::gui::NumberSlider("Progress", [this]() { return dt_; }, [](double) {}, 0, duration_),
-      mc_rtc::gui::Button("Stop Motion", [this]() {
-        mc_rtc::log::warning("[{}] Motion was interrupted before it's planned duration ({:.2f}/{:.2f}s)", name(), dt_,
-                             duration_);
-        interrupted_ = true;
-      }));
+  ctl.gui()->addElement({},
+                        mc_rtc::gui::NumberSlider(
+                            "Progress", [this]() { return dt_; }, [](double) {}, 0, duration_),
+                        mc_rtc::gui::Button("Stop Motion", [this]() {
+                          mc_rtc::log::warning(
+                              "[{}] Motion was interrupted before it's planned duration ({:.2f}/{:.2f}s)", name(), dt_,
+                              duration_);
+                          interrupted_ = true;
+                        }));
 }
 
 bool CalibrationMotion::run(mc_control::fsm::Controller & ctl_)

--- a/src/states/CheckResults.cpp
+++ b/src/states/CheckResults.cpp
@@ -48,18 +48,21 @@ void CheckResults::start(mc_control::fsm::Controller & ctl)
 
     ctl.gui()->addPlot(
         sensorN, plot::X({"t", {t_ + 0, t_ + duration}}, [this]() { return t_; }),
-        plot::Y("Wrenches calibrated (x)",
-                [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().x(); }, Color::Red,
-                Style::Solid),
-        plot::Y("Wrenches calibrated (y)",
-                [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().y(); }, Color::Green,
-                Style::Solid),
-        plot::Y("Wrenches calibrated (y)",
-                [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().z(); }, Color::Blue,
-                Style::Solid),
-        plot::Y("Wrenches raw(x)", [&sensor]() { return sensor.wrench().force().x(); }, Color::Red, Style::Dashed),
-        plot::Y("Wrenches raw(y)", [&sensor]() { return sensor.wrench().force().y(); }, Color::Green, Style::Dashed),
-        plot::Y("Wrenches raw(z)", [&sensor]() { return sensor.wrench().force().z(); }, Color::Blue, Style::Dashed));
+        plot::Y(
+            "Wrenches calibrated (x)", [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().x(); },
+            Color::Red, Style::Solid),
+        plot::Y(
+            "Wrenches calibrated (y)", [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().y(); },
+            Color::Green, Style::Solid),
+        plot::Y(
+            "Wrenches calibrated (y)", [&robot, &sensor]() { return sensor.wrenchWithoutGravity(robot).force().z(); },
+            Color::Blue, Style::Solid),
+        plot::Y(
+            "Wrenches raw(x)", [&sensor]() { return sensor.wrench().force().x(); }, Color::Red, Style::Dashed),
+        plot::Y(
+            "Wrenches raw(y)", [&sensor]() { return sensor.wrench().force().y(); }, Color::Green, Style::Dashed),
+        plot::Y(
+            "Wrenches raw(z)", [&sensor]() { return sensor.wrench().force().z(); }, Color::Blue, Style::Dashed));
   }
 
   ctl.gui()->addElement(

--- a/src/states/RunCalibrationScript.cpp
+++ b/src/states/RunCalibrationScript.cpp
@@ -73,15 +73,20 @@ void RunCalibrationScript::start(mc_control::fsm::Controller & ctl_)
     }
     completed_ = true;
   });
+#ifndef WIN32
   // Lower thread priority so that it has a lesser priority than the real time
   // thread
   auto th_handle = th_.native_handle();
   int policy = 0;
   sched_param param{};
   pthread_getschedparam(th_handle, &policy, &param);
-  mc_rtc::log::info("[{}] Calibration thread priority: {}", name(), param.sched_priority);
   param.sched_priority = 80;
-  pthread_setschedparam(th_handle, SCHED_RR, &param);
+  if(pthread_setschedparam(th_handle, SCHED_RR, &param) != 0)
+  {
+    mc_rtc::log::warning("[{}] Failed to lower calibration thread priority. If you are running on a real-time system, "
+                         "this might cause latency to the real-time loop.");
+  }
+#endif
 }
 
 bool RunCalibrationScript::run(mc_control::fsm::Controller &)

--- a/src/states/RunCalibrationScript.cpp
+++ b/src/states/RunCalibrationScript.cpp
@@ -73,6 +73,15 @@ void RunCalibrationScript::start(mc_control::fsm::Controller & ctl_)
     }
     completed_ = true;
   });
+  // Lower thread priority so that it has a lesser priority than the real time
+  // thread
+  auto th_handle = th_.native_handle();
+  int policy = 0;
+  sched_param param{};
+  pthread_getschedparam(th_handle, &policy, &param);
+  mc_rtc::log::info("[{}] Calibration thread priority: {}", name(), param.sched_priority);
+  param.sched_priority = 80;
+  pthread_setschedparam(th_handle, SCHED_RR, &param);
 }
 
 bool RunCalibrationScript::run(mc_control::fsm::Controller &)

--- a/src/states/ShowForces.cpp
+++ b/src/states/ShowForces.cpp
@@ -17,9 +17,12 @@ void ShowForces::addWrenchPlot(const std::string & name,
                                const mc_rbdyn::ForceSensor & fs)
 {
   gui.addPlot(name, plot::X("t", [this]() { return t_; }),
-              plot::Y(name + " (x)", [&fs]() { return fs.wrench().force().x(); }, Color::Red, Style::Dashed),
-              plot::Y(name + " (y)", [&fs]() { return fs.wrench().force().y(); }, Color::Green, Style::Dashed),
-              plot::Y(name + " (z)", [&fs]() { return fs.wrench().force().z(); }, Color::Blue, Style::Dashed));
+              plot::Y(
+                  name + " (x)", [&fs]() { return fs.wrench().force().x(); }, Color::Red, Style::Dashed),
+              plot::Y(
+                  name + " (y)", [&fs]() { return fs.wrench().force().y(); }, Color::Green, Style::Dashed),
+              plot::Y(
+                  name + " (z)", [&fs]() { return fs.wrench().force().z(); }, Color::Blue, Style::Dashed));
   plots_.push_back(name);
 }
 
@@ -29,12 +32,15 @@ void ShowForces::addWrenchWithoutGravityPlot(const std::string & name,
                                              const mc_rbdyn::ForceSensor & fs)
 {
   gui.addPlot(name, plot::X("t", [this]() { return t_; }),
-              plot::Y(name + " (x)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().x(); }, Color::Red,
-                      Style::Dashed),
-              plot::Y(name + " (y)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().y(); },
-                      Color::Green, Style::Dashed),
-              plot::Y(name + " (z)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().z(); },
-                      Color::Blue, Style::Dashed));
+              plot::Y(
+                  name + " (x)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().x(); }, Color::Red,
+                  Style::Dashed),
+              plot::Y(
+                  name + " (y)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().y(); }, Color::Green,
+                  Style::Dashed),
+              plot::Y(
+                  name + " (z)", [&robot, &fs]() { return fs.wrenchWithoutGravity(robot).force().z(); }, Color::Blue,
+                  Style::Dashed));
   plots_.push_back(name);
 }
 
@@ -45,12 +51,15 @@ void ShowForces::addWrenchWithoutGravityPlot(const std::string & name,
                                              const mc_rbdyn::ForceSensor & fs)
 {
   gui.addPlot(name, plot::X("t", [this]() { return t_; }),
-              plot::Y(name + " (x)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().x(); },
-                      Color::Red, Style::Dashed),
-              plot::Y(name + " (y)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().y(); },
-                      Color::Green, Style::Dashed),
-              plot::Y(name + " (z)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().z(); },
-                      Color::Blue, Style::Dashed));
+              plot::Y(
+                  name + " (x)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().x(); },
+                  Color::Red, Style::Dashed),
+              plot::Y(
+                  name + " (y)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().y(); },
+                  Color::Green, Style::Dashed),
+              plot::Y(
+                  name + " (z)", [&robot, &fs, surface]() { return robot.surfaceWrench(surface).force().z(); },
+                  Color::Blue, Style::Dashed));
   plots_.push_back(name);
 }
 
@@ -59,8 +68,9 @@ void ShowForces::addWrenchVector(const std::string & name,
                                  const mc_rbdyn::Robot & robot,
                                  const mc_rbdyn::ForceSensor & fs)
 {
-  gui.addElement(category_, Force(name, forceConfig_, [&fs]() { return fs.wrench(); },
-                                  [&fs, &robot]() { return fs.X_0_f(robot); }));
+  gui.addElement(category_,
+                 Force(
+                     name, forceConfig_, [&fs]() { return fs.wrench(); }, [&fs, &robot]() { return fs.X_0_f(robot); }));
 }
 
 void ShowForces::addWrenchWithoutGravityVector(const std::string & name,
@@ -68,8 +78,9 @@ void ShowForces::addWrenchWithoutGravityVector(const std::string & name,
                                                const mc_rbdyn::Robot & robot,
                                                const mc_rbdyn::ForceSensor & fs)
 {
-  gui.addElement(category_, Force(name, forceConfig_, [&fs, &robot]() { return fs.wrenchWithoutGravity(robot); },
-                                  [&fs, &robot]() { return fs.X_0_f(robot); }));
+  gui.addElement(category_, Force(
+                                name, forceConfig_, [&fs, &robot]() { return fs.wrenchWithoutGravity(robot); },
+                                [&fs, &robot]() { return fs.X_0_f(robot); }));
 }
 
 void ShowForces::addWrenchWithoutGravityVector(const std::string & name,
@@ -78,8 +89,9 @@ void ShowForces::addWrenchWithoutGravityVector(const std::string & name,
                                                const mc_rbdyn::Robot & robot,
                                                const mc_rbdyn::ForceSensor & fs)
 {
-  gui.addElement(category_, Force(name, forceConfig_, [&fs, &robot, surface]() { return robot.surfaceWrench(surface); },
-                                  [&fs, &robot, surface]() { return robot.surfacePose(surface); }));
+  gui.addElement(category_, Force(
+                                name, forceConfig_, [&fs, &robot, surface]() { return robot.surfaceWrench(surface); },
+                                [&fs, &robot, surface]() { return robot.surfacePose(surface); }));
 }
 
 void ShowForces::start(mc_control::fsm::Controller & ctl)
@@ -143,12 +155,12 @@ void ShowForces::start(mc_control::fsm::Controller & ctl)
     if(surfaces.size())
     {
       surfaces_[name] = surfaces.front();
-      ctl.gui()->addElement(fsCategory,
-                            mc_rtc::gui::ComboInput("Surface", surfaces, [this, name]() { return surfaces_[name]; },
-                                                    [this, name](const std::string & surface) {
-                                                      mc_rtc::log::info("[ShowForces] Surface {} selected", surface);
-                                                      surfaces_[name] = surface;
-                                                    }));
+      ctl.gui()->addElement(fsCategory, mc_rtc::gui::ComboInput(
+                                            "Surface", surfaces, [this, name]() { return surfaces_[name]; },
+                                            [this, name](const std::string & surface) {
+                                              mc_rtc::log::info("[ShowForces] Surface {} selected", surface);
+                                              surfaces_[name] = surface;
+                                            }));
       // mc  _rtc::gui::FormDataComboInput{"R0 surface", false, {"surfaces", "$R0"}},
 
       ctl.gui()->addElement(fsCategory, ElementsStacking::Horizontal,


### PR DESCRIPTION
Currently, the initial guess for the weight of the link attached to the force sensor is wrong: we use the parent link of the force sensor. That is in theory a link above the sensor, and thus it shouldn't be taken into account. On `HRP` robot this kinda worked because the robot model structure is odd: the force sensor's parent link includes both:
- the sensor attachment plate
- the sensor
- and the gripper/foot 

Thus our initial guess was also including the force sensor's and its base plate's weight, which is incorrect.


The code in this PR automatically computes the correct initial guess for the `mass` and `com` of the link, assuming that the robot model is correct (that is, that the children of the force sensor link are indeed its children).

I'll leave this PR as a draft until:
- The robot models are updated (see https://github.com/isri-aist/hrp2kai/issues/20)
- I'll add a configuration mechanism to allow providing our own initial guess in case the model is not suitable for using this method.